### PR TITLE
#11 - update deploy yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
-name: Java CI
+name: Java CI and Release
 
 on:
-  push:
-    branches: [ "master" ]
-    
+  release:
+    types: [released]
+
 permissions:
   contents: read
 
@@ -11,31 +11,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-
-    - name: Build Java Game
-      run: |
-        # Assuming your game's entry point is Main.java and the package is com.example.game
-        javac -source 17 -target 17 -d build src/com/vulps/main/*.java
-        
-    - name: Package JAR
-      run: |
-        mkdir -p build
-        cp src/META-INF/MANIFEST.MF build/
-        cp -R src/resources build/
-        jar cvfm vortex-evader.jar build/MANIFEST.MF -C build .
-
-
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: vortex-evader-artifact
-        path: vortex-evader.jar
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build Java Game
+        run: |
+          # Compile your source code (adjust paths as necessary)
+          javac -source 17 -target 17 -d build src/com/vulps/main/*.java
+      - name: Package JAR
+        run: |
+          mkdir -p build
+          cp src/META-INF/MANIFEST.MF build/
+          cp -R src/resources build/
+          jar cvfm vortex-evader.jar build/MANIFEST.MF -C build .
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: vortex-evader-artifact
+          path: vortex-evader.jar
 
   release:
     runs-on: ubuntu-latest
@@ -43,23 +39,17 @@ jobs:
     env:
       BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
     steps:
-    - name: Install Butler
-      run: |
-        # -L follows redirects
-        # -O specifies output name
-        curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
-        unzip butler.zip
-        # GNU unzip tends to not set the executable bit even though it's set in the .zip
-        chmod +x butler
-        # just a sanity check run (and also helpful in case you're sharing CI logs)
-        echo "API_KEY=$BUTLER_API_KEY" >> $GITHUB_ENV
-        ./butler -V
-
-    - name: Download Artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: vortex-evader-artifact
-
-    - name: Create Patch and Push
-      run: |
-        ./butler push vortex-evader.jar vulps23/vortex-evader:alpha-win-mac-linux
+      - name: Install Butler
+        run: |
+          curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+          unzip butler.zip
+          chmod +x butler
+          echo "API_KEY=$BUTLER_API_KEY" >> $GITHUB_ENV
+          ./butler -V
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: vortex-evader-artifact
+      - name: Create Patch and Push
+        run: |
+          ./butler push vortex-evader.jar vulps23/vortex-evader:alpha-win-mac-linux

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '24'
           distribution: 'temurin'
       - name: Build Java Game
         run: |
           # Compile your source code (adjust paths as necessary)
-          javac -source 17 -target 17 -d build src/com/vulps/main/*.java
+           javac --release 17 -d build src/com/vulps/main/**/*.java
       - name: Package JAR
         run: |
           mkdir -p build


### PR DESCRIPTION
We can now use tags to control releases instead of every push to master (this is a step towards creating a current-release branch)

We're also building on java 24 now, while still targeting 17